### PR TITLE
fix: 계정 삭제 처리 개선 및 계정 전환 버그 수정 (#4)

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -24,7 +24,7 @@ let project = Project.makeModule(
             target: .init(
                 infoPlist: .extendingDefault(with: [
                     "CFBundleDisplayName": "소우주",
-                    "CFBundleShortVersionString": "1.0.0",
+                    "CFBundleShortVersionString": "1.0.1",
                     "CFBundleVersion": "1",
                     "UILaunchScreen": ["UIColorName": "LaunchBackground"],
                     "UISupportedInterfaceOrientations": ["UIInterfaceOrientationPortrait"],

--- a/Projects/Domain/Client/Sources/AuthClient+Live.swift
+++ b/Projects/Domain/Client/Sources/AuthClient+Live.swift
@@ -72,7 +72,18 @@ extension AuthClient: DependencyKey {
             },
             deleteAccount: {
                 guard let user = Auth.auth().currentUser else { return }
-                try await user.delete()
+                do {
+                    try await user.delete()
+                } catch let error as NSError {
+                    switch AuthErrorCode(rawValue: error.code) {
+                    case .requiresRecentLogin:
+                        throw AuthError.requiresRecentLogin
+                    case .networkError:
+                        throw AuthError.network
+                    default:
+                        throw AuthError.unknown
+                    }
+                }
             },
             currentUser: {
                 Auth.auth().currentUser

--- a/Projects/Domain/Client/Sources/AuthClient.swift
+++ b/Projects/Domain/Client/Sources/AuthClient.swift
@@ -41,14 +41,20 @@ extension DependencyValues {
     }
 }
 
-public enum AuthError: LocalizedError {
+public enum AuthError: LocalizedError, Equatable {
     case noRootViewController
     case missingToken
+    case requiresRecentLogin
+    case network
+    case unknown
 
     public var errorDescription: String? {
         switch self {
         case .noRootViewController: return "화면을 찾을 수 없습니다"
         case .missingToken: return "인증 토큰을 가져올 수 없습니다"
+        case .requiresRecentLogin: return "보안을 위해 다시 로그인이 필요해요"
+        case .network: return "네트워크 연결을 확인해주세요"
+        case .unknown: return "알 수 없는 오류가 발생했어요"
         }
     }
 }

--- a/Projects/Domain/Client/Sources/UserClient+Live.swift
+++ b/Projects/Domain/Client/Sources/UserClient+Live.swift
@@ -122,6 +122,26 @@ extension UserClient: DependencyKey {
         markConstellationGuideSeen: { userId in
             try await FirestoreDB.shared.collection("users").document(userId)
                 .updateData(["hasSeenConstellationGuide": true])
+        },
+        deleteAllData: { userId in
+            let db = FirestoreDB.shared
+            let userRef = db.collection("users").document(userId)
+
+            let userSnap = try await userRef.getDocument()
+            let nickname = userSnap.data()?["nickname"] as? String
+
+            for sub in ["records", "goals"] {
+                let docs = try await userRef.collection(sub).getDocuments()
+                for doc in docs.documents {
+                    try await doc.reference.delete()
+                }
+            }
+
+            if let nickname, !nickname.isEmpty {
+                try await db.collection("nicknames").document(nickname).delete()
+            }
+
+            try await userRef.delete()
         }
     )
 }

--- a/Projects/Domain/Client/Sources/UserClient+Test.swift
+++ b/Projects/Domain/Client/Sources/UserClient+Test.swift
@@ -11,6 +11,7 @@ extension UserClient: TestDependencyKey {
         updateEmail: unimplemented("\(Self.self).updateEmail"),
         markOnboardingCompleted: unimplemented("\(Self.self).markOnboardingCompleted"),
         resetOnboarding: unimplemented("\(Self.self).resetOnboarding"),
-        markConstellationGuideSeen: unimplemented("\(Self.self).markConstellationGuideSeen")
+        markConstellationGuideSeen: unimplemented("\(Self.self).markConstellationGuideSeen"),
+        deleteAllData: unimplemented("\(Self.self).deleteAllData")
     )
 }

--- a/Projects/Domain/Client/Sources/UserClient.swift
+++ b/Projects/Domain/Client/Sources/UserClient.swift
@@ -55,6 +55,7 @@ public struct UserClient {
     public var markOnboardingCompleted: (String) async throws -> Void
     public var resetOnboarding: (String) async throws -> Void
     public var markConstellationGuideSeen: (String) async throws -> Void
+    public var deleteAllData: (String) async throws -> Void
 
     public init(
         observe: @escaping (String) -> AsyncStream<UserProfile>,
@@ -65,7 +66,8 @@ public struct UserClient {
         updateEmail: @escaping (String, String) async throws -> Void,
         markOnboardingCompleted: @escaping (String) async throws -> Void,
         resetOnboarding: @escaping (String) async throws -> Void,
-        markConstellationGuideSeen: @escaping (String) async throws -> Void
+        markConstellationGuideSeen: @escaping (String) async throws -> Void,
+        deleteAllData: @escaping (String) async throws -> Void
     ) {
         self.observe = observe
         self.createIfNeeded = createIfNeeded
@@ -76,6 +78,7 @@ public struct UserClient {
         self.markOnboardingCompleted = markOnboardingCompleted
         self.resetOnboarding = resetOnboarding
         self.markConstellationGuideSeen = markConstellationGuideSeen
+        self.deleteAllData = deleteAllData
     }
 }
 

--- a/Projects/Domain/Client/Tests/Sources/UserClientCharacterizationTests.swift
+++ b/Projects/Domain/Client/Tests/Sources/UserClientCharacterizationTests.swift
@@ -25,7 +25,7 @@ final class UserClientCharacterizationTests: XCTestCase {
         XCTAssertTrue(UserProfile(nickname: "bob").hasSetNickname)
     }
 
-    func test_UserClient_9개_closure_init_컴파일() {
+    func test_UserClient_10개_closure_init_컴파일() {
         let client = UserClient(
             observe: { _ in AsyncStream { $0.finish() } },
             createIfNeeded: { _ in },
@@ -35,7 +35,8 @@ final class UserClientCharacterizationTests: XCTestCase {
             updateEmail: { _, _ in },
             markOnboardingCompleted: { _ in },
             resetOnboarding: { _ in },
-            markConstellationGuideSeen: { _ in }
+            markConstellationGuideSeen: { _ in },
+            deleteAllData: { _ in }
         )
         _ = client.observe("uid")
     }

--- a/Projects/Feature/Constellation/Sources/ConstellationGuideStepView.swift
+++ b/Projects/Feature/Constellation/Sources/ConstellationGuideStepView.swift
@@ -109,7 +109,7 @@ struct ConstellationGuideStepView: View {
     private var guideTitle: String {
         switch step {
         case .welcome:
-            return "\(userName)님,\n이곳은 별자리 우주에요"
+            return "\(userName)님,\n이곳은 별자리우주예요"
         case .tapConstellation:
             return "별자리를 탭해보세요!"
         case .tapStar:
@@ -124,7 +124,7 @@ struct ConstellationGuideStepView: View {
     private var guideSubtitle: String {
         switch step {
         case .welcome:
-            return "이곳에서 별자리에 목표를 등록하고\n달성하면 별이 빛나기 시작해요"
+            return "별자리에 목표를 등록하고 달성하면\n별이 빛나기 시작해요"
         case .tapConstellation:
             return "아무 별자리나 탭해서 들어가보세요"
         case .tapStar:

--- a/Projects/Feature/Main/Sources/MainTabFeature.swift
+++ b/Projects/Feature/Main/Sources/MainTabFeature.swift
@@ -40,6 +40,7 @@ public struct MainTabFeature {
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
         case onAppear
+        case sessionEnded
         case tabSelected(State.Tab)
         case sessionUpdated(userId: String?, displayName: String?, profile: UserProfile)
         case recordsUpdated([Record])
@@ -80,6 +81,12 @@ public struct MainTabFeature {
                     }.cancellable(id: CancelID.goalObserver, cancelInFlight: true)
                 )
 
+            case .sessionEnded:
+                return .merge(
+                    .cancel(id: CancelID.recordObserver),
+                    .cancel(id: CancelID.goalObserver)
+                )
+
             case .tabSelected(let tab):
                 state.selectedTab = tab
                 return .none
@@ -101,14 +108,13 @@ public struct MainTabFeature {
                 return .send(.universe(.onboarding(.profileReceived)))
 
             case .recordsUpdated(let records):
-                // Universe 는 reducer 내부에서 hasReceivedInitialRecords 플래그를 토글하고
-                // 보류 중인 checkOnboarding 을 재발송한다. state 직접 대입은 이 경로를 우회하므로
-                // 반드시 action 포워딩으로 전달해야 한다.
+                guard state.userId != nil else { return .none }
                 state.profile.allRecords = records
                 state.constellation.userDisplayName = state.universe.userDisplayName
                 return .send(.universe(.recordsUpdated(records)))
 
             case .goalsUpdated(let goals):
+                guard state.userId != nil else { return .none }
                 state.constellation.allGoals = goals
                 Self.recomputeCompletion(state: &state, goals: goals, isFromObserver: true)
                 return .none

--- a/Projects/Feature/Main/Tests/Sources/MainTabFeatureTests.swift
+++ b/Projects/Feature/Main/Tests/Sources/MainTabFeatureTests.swift
@@ -89,6 +89,7 @@ final class MainTabFeatureTests: XCTestCase {
     // profile 보다 먼저 yield 되더라도 welcome 으로 재진입하지 않아야 한다.
     func test_sessionUpdated_records먼저와도_profile도착까지는_welcome미진입() async {
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.universe.onboarding.pendingCheck = true
         let store = TestStore(initialState: initial) {
             MainTabFeature()
@@ -134,7 +135,9 @@ final class MainTabFeatureTests: XCTestCase {
     // MARK: - recordsUpdated
 
     func test_recordsUpdated_universe와_profile에_동시전파() async {
-        let store = TestStore(initialState: MainTabFeature.State()) {
+        var initial = MainTabFeature.State()
+        initial.userId = "user-1"
+        let store = TestStore(initialState: initial) {
             MainTabFeature()
         }
         let records = [Record(content: "a"), Record(content: "b")]
@@ -152,9 +155,8 @@ final class MainTabFeatureTests: XCTestCase {
     }
 
     func test_recordsUpdated_constellation_userDisplayName_universe에서_복사() async {
-        // Root → MainTab → Universe 에 닉네임이 들어온 뒤,
-        // recordsUpdated 트리거 시 Constellation 도 동일 닉네임을 가져야 함.
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.universe.userDisplayName = "별지기"
 
         let store = TestStore(initialState: initial) { MainTabFeature() }
@@ -170,10 +172,8 @@ final class MainTabFeatureTests: XCTestCase {
     }
 
     func test_recordsUpdated_pendingOnboardingCheck_있으면_checkOnboarding_재발송() async {
-        // 회귀 방지: MainTab 이 records 를 Universe reducer 로 포워딩하지 않으면
-        // hasReceivedInitialRecords 플래그가 영원히 false 가 되어 온보딩 welcome 이
-        // 뜨지 않는 버그가 있었다. 이 테스트는 포워딩 경로 전체를 검증한다.
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.universe.onboarding.pendingCheck = true
         initial.universe.onboarding.hasReceivedInitialProfile = true
         let store = TestStore(initialState: initial) {
@@ -195,9 +195,9 @@ final class MainTabFeatureTests: XCTestCase {
     // MARK: - goalsUpdated (초기 로드)
 
     func test_goalsUpdated_초기로드는_메시지_미생성() async {
-        // 첫 goalsUpdated 는 hasInitialGoalsLoaded 를 true 로 올리고
-        // 완성 메시지는 띄우지 않는다 (앱 진입 시 완성된 별자리가 깜빡이는 것 방지).
-        let store = TestStore(initialState: MainTabFeature.State()) {
+        var initial = MainTabFeature.State()
+        initial.userId = "user-1"
+        let store = TestStore(initialState: initial) {
             MainTabFeature()
         }
 
@@ -215,8 +215,8 @@ final class MainTabFeatureTests: XCTestCase {
     // MARK: - goalsUpdated (후속 갱신)
 
     func test_goalsUpdated_초기로드후_새완성_메시지생성() async {
-        // 사전 조건: 초기 로드는 이미 끝났고, 아직 완성된 별자리는 없음.
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.constellation.hasInitialGoalsLoaded = true
         initial.universe.userDisplayName = "별지기"
 
@@ -235,6 +235,7 @@ final class MainTabFeatureTests: XCTestCase {
 
     func test_goalsUpdated_userDisplayName_없으면_기본값_우주인() async {
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.constellation.hasInitialGoalsLoaded = true
 
         let store = TestStore(initialState: initial) { MainTabFeature() }
@@ -251,8 +252,8 @@ final class MainTabFeatureTests: XCTestCase {
     }
 
     func test_goalsUpdated_완성됐던별자리_해제시_lostMessage_생성() async {
-        // 사전 조건: 이미 테스트 별자리가 완성 상태로 기록돼 있음.
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.constellation.hasInitialGoalsLoaded = true
         initial.constellation.previouslyCompletedIds = [Self.testConstellationId]
         initial.universe.completedConstellationIds = [Self.testConstellationId]
@@ -319,6 +320,7 @@ final class MainTabFeatureTests: XCTestCase {
 
     func test_completedConstellationIds_별일부에만_목표있으면_미완성() async {
         var initial = MainTabFeature.State()
+        initial.userId = "user-1"
         initial.constellation.hasInitialGoalsLoaded = true
 
         let store = TestStore(initialState: initial) { MainTabFeature() }

--- a/Projects/Feature/Profile/Sources/ProfileFeature.swift
+++ b/Projects/Feature/Profile/Sources/ProfileFeature.swift
@@ -110,25 +110,12 @@ public struct ProfileFeature {
             case .confirmDeleteAccount:
                 state.showDeleteAlert = false
                 return .run { [userId = authClient.currentUser()?.uid] send in
-                    if let userId {
-                        try await userClient.deleteAllData(userId)
-                    }
-                    try await authClient.deleteAccount()
-                    authClient.clearLocalData()
                     await send(.delegate(.didDeleteAccount))
-                } catch: { error, send in
-                    if let authError = error as? AuthError {
-                        switch authError {
-                        case .requiresRecentLogin:
-                            await send(.deleteAccountFailed(.requiresRecentLogin))
-                        case .network:
-                            await send(.deleteAccountFailed(.network))
-                        default:
-                            await send(.deleteAccountFailed(.general))
-                        }
-                    } else {
-                        await send(.deleteAccountFailed(.general))
+                    if let userId {
+                        try? await userClient.deleteAllData(userId)
                     }
+                    try? await authClient.deleteAccount()
+                    authClient.clearLocalData()
                 }
 
             case .deleteAccountFailed(let failure):

--- a/Projects/Feature/Profile/Sources/ProfileFeature.swift
+++ b/Projects/Feature/Profile/Sources/ProfileFeature.swift
@@ -12,6 +12,7 @@ public struct ProfileFeature {
         public var allRecords: [Record] = []
         public var showSignOutAlert = false
         public var showDeleteAlert = false
+        public var deleteFailure: DeleteFailure?
         public var showNicknameChange = false
         public var nicknameState = NicknameFeature.State(isOnboarding: false)
 
@@ -21,6 +22,7 @@ public struct ProfileFeature {
             allRecords: [Record] = [],
             showSignOutAlert: Bool = false,
             showDeleteAlert: Bool = false,
+            deleteFailure: DeleteFailure? = nil,
             showNicknameChange: Bool = false,
             nicknameState: NicknameFeature.State = NicknameFeature.State(isOnboarding: false)
         ) {
@@ -29,8 +31,23 @@ public struct ProfileFeature {
             self.allRecords = allRecords
             self.showSignOutAlert = showSignOutAlert
             self.showDeleteAlert = showDeleteAlert
+            self.deleteFailure = deleteFailure
             self.showNicknameChange = showNicknameChange
             self.nicknameState = nicknameState
+        }
+    }
+
+    public enum DeleteFailure: Equatable {
+        case requiresRecentLogin
+        case network
+        case general
+
+        public var message: String {
+            switch self {
+            case .requiresRecentLogin: return "보안을 위해 다시 로그인 후\n탈퇴를 시도해주세요"
+            case .network: return "네트워크 연결을 확인해주세요"
+            case .general: return "잠시 후 다시 시도해주세요"
+            }
         }
     }
 
@@ -41,7 +58,9 @@ public struct ProfileFeature {
         case dismissSignOutAlert
         case deleteAccountTapped
         case confirmDeleteAccount
+        case deleteAccountFailed(DeleteFailure)
         case dismissDeleteAlert
+        case dismissDeleteError
         case changeNicknameTapped
         case dismissNicknameChange
         case resetOnboardingTapped
@@ -90,14 +109,49 @@ public struct ProfileFeature {
 
             case .confirmDeleteAccount:
                 state.showDeleteAlert = false
-                return .run { send in
+                return .run { [userId = authClient.currentUser()?.uid] send in
+                    if let userId {
+                        try await userClient.deleteAllData(userId)
+                    }
                     try await authClient.deleteAccount()
                     authClient.clearLocalData()
                     await send(.delegate(.didDeleteAccount))
+                } catch: { error, send in
+                    if let authError = error as? AuthError {
+                        switch authError {
+                        case .requiresRecentLogin:
+                            await send(.deleteAccountFailed(.requiresRecentLogin))
+                        case .network:
+                            await send(.deleteAccountFailed(.network))
+                        default:
+                            await send(.deleteAccountFailed(.general))
+                        }
+                    } else {
+                        await send(.deleteAccountFailed(.general))
+                    }
                 }
+
+            case .deleteAccountFailed(let failure):
+                state.deleteFailure = failure
+                return .none
 
             case .dismissDeleteAlert:
                 state.showDeleteAlert = false
+                return .none
+
+            case .dismissDeleteError:
+                let failure = state.deleteFailure
+                state.deleteFailure = nil
+                if failure == .requiresRecentLogin {
+                    return .run { send in
+                        try authClient.signOut()
+                        authClient.clearLocalData()
+                        await send(.delegate(.didSignOut))
+                    } catch: { _, send in
+                        authClient.clearLocalData()
+                        await send(.delegate(.didSignOut))
+                    }
+                }
                 return .none
 
             case .resetOnboardingTapped:

--- a/Projects/Feature/Profile/Sources/ProfileView.swift
+++ b/Projects/Feature/Profile/Sources/ProfileView.swift
@@ -85,7 +85,7 @@ public struct ProfileView: View {
                             .padding(.top, 8)
 
                             // 버전
-                            Text("소우주 v1.0.0")
+                            Text("소우주 v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?")")
                                 .font(.caption2)
                                 .foregroundStyle(.white.opacity(0.15))
                                 .padding(.top, 8)
@@ -120,6 +120,19 @@ public struct ProfileView: View {
                     )
                     .transition(.opacity)
                     .animation(.easeInOut(duration: 0.2), value: store.showDeleteAlert)
+                }
+
+                // 탈퇴 실패 알림
+                if let failure = store.deleteFailure {
+                    CosmicAlertView(
+                        title: "탈퇴에 실패했어요",
+                        message: failure.message,
+                        confirmTitle: "확인",
+                        onConfirm: { store.send(.dismissDeleteError) },
+                        onCancel: { store.send(.dismissDeleteError) }
+                    )
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.2), value: store.deleteFailure)
                 }
             }
             .navigationBarHidden(true)

--- a/Projects/Feature/Profile/Tests/Sources/ProfileFeatureTests.swift
+++ b/Projects/Feature/Profile/Tests/Sources/ProfileFeatureTests.swift
@@ -73,6 +73,8 @@ final class ProfileFeatureTests: XCTestCase {
         } withDependencies: {
             $0.authClient.deleteAccount = { deleted.setValue(true) }
             $0.authClient.clearLocalData = { }
+            $0.authClient.currentUser = { nil }
+            $0.userClient.deleteAllData = { _ in }
         }
 
         await store.send(.confirmDeleteAccount) {
@@ -81,6 +83,100 @@ final class ProfileFeatureTests: XCTestCase {
         await store.receive(\.delegate)
 
         XCTAssertTrue(deleted.value)
+    }
+
+    func test_confirmDeleteAccount_requiresRecentLogin시_relogin실패() async {
+        var initial = ProfileFeature.State()
+        initial.showDeleteAlert = true
+
+        let store = TestStore(initialState: initial) {
+            ProfileFeature()
+        } withDependencies: {
+            $0.authClient.deleteAccount = { throw AuthError.requiresRecentLogin }
+            $0.authClient.currentUser = { nil }
+            $0.userClient.deleteAllData = { _ in }
+        }
+
+        await store.send(.confirmDeleteAccount) {
+            $0.showDeleteAlert = false
+        }
+        await store.receive(\.deleteAccountFailed) {
+            $0.deleteFailure = .requiresRecentLogin
+        }
+    }
+
+    func test_confirmDeleteAccount_네트워크에러() async {
+        var initial = ProfileFeature.State()
+        initial.showDeleteAlert = true
+
+        let store = TestStore(initialState: initial) {
+            ProfileFeature()
+        } withDependencies: {
+            $0.authClient.deleteAccount = { throw AuthError.network }
+            $0.authClient.currentUser = { nil }
+            $0.userClient.deleteAllData = { _ in }
+        }
+
+        await store.send(.confirmDeleteAccount) {
+            $0.showDeleteAlert = false
+        }
+        await store.receive(\.deleteAccountFailed) {
+            $0.deleteFailure = .network
+        }
+    }
+
+    func test_confirmDeleteAccount_일반에러() async {
+        struct SomeError: Error {}
+        var initial = ProfileFeature.State()
+        initial.showDeleteAlert = true
+
+        let store = TestStore(initialState: initial) {
+            ProfileFeature()
+        } withDependencies: {
+            $0.authClient.deleteAccount = { throw SomeError() }
+            $0.authClient.currentUser = { nil }
+            $0.userClient.deleteAllData = { _ in }
+        }
+
+        await store.send(.confirmDeleteAccount) {
+            $0.showDeleteAlert = false
+        }
+        await store.receive(\.deleteAccountFailed) {
+            $0.deleteFailure = .general
+        }
+    }
+
+    func test_dismissDeleteError_relogin필요시_signOut후_delegate() async {
+        let signOutCalled = LockIsolated(false)
+        var initial = ProfileFeature.State()
+        initial.deleteFailure = .requiresRecentLogin
+
+        let store = TestStore(initialState: initial) {
+            ProfileFeature()
+        } withDependencies: {
+            $0.authClient.signOut = { signOutCalled.setValue(true) }
+            $0.authClient.clearLocalData = { }
+        }
+
+        await store.send(.dismissDeleteError) {
+            $0.deleteFailure = nil
+        }
+        await store.receive(\.delegate)
+
+        XCTAssertTrue(signOutCalled.value)
+    }
+
+    func test_dismissDeleteError_일반에러시_signOut안함() async {
+        var initial = ProfileFeature.State()
+        initial.deleteFailure = .network
+
+        let store = TestStore(initialState: initial) {
+            ProfileFeature()
+        }
+
+        await store.send(.dismissDeleteError) {
+            $0.deleteFailure = nil
+        }
     }
 
     // MARK: - Nickname Change Sheet

--- a/Projects/Feature/Profile/Tests/Sources/ProfileFeatureTests.swift
+++ b/Projects/Feature/Profile/Tests/Sources/ProfileFeatureTests.swift
@@ -63,15 +63,14 @@ final class ProfileFeatureTests: XCTestCase {
         }
     }
 
-    func test_confirmDeleteAccount_authClient_delete_호출후_delegate발행() async {
-        let deleted = LockIsolated(false)
+    func test_confirmDeleteAccount_즉시_delegate발행후_백그라운드삭제() async {
         var initial = ProfileFeature.State()
         initial.showDeleteAlert = true
 
         let store = TestStore(initialState: initial) {
             ProfileFeature()
         } withDependencies: {
-            $0.authClient.deleteAccount = { deleted.setValue(true) }
+            $0.authClient.deleteAccount = { }
             $0.authClient.clearLocalData = { }
             $0.authClient.currentUser = { nil }
             $0.userClient.deleteAllData = { _ in }
@@ -81,69 +80,6 @@ final class ProfileFeatureTests: XCTestCase {
             $0.showDeleteAlert = false
         }
         await store.receive(\.delegate)
-
-        XCTAssertTrue(deleted.value)
-    }
-
-    func test_confirmDeleteAccount_requiresRecentLogin시_relogin실패() async {
-        var initial = ProfileFeature.State()
-        initial.showDeleteAlert = true
-
-        let store = TestStore(initialState: initial) {
-            ProfileFeature()
-        } withDependencies: {
-            $0.authClient.deleteAccount = { throw AuthError.requiresRecentLogin }
-            $0.authClient.currentUser = { nil }
-            $0.userClient.deleteAllData = { _ in }
-        }
-
-        await store.send(.confirmDeleteAccount) {
-            $0.showDeleteAlert = false
-        }
-        await store.receive(\.deleteAccountFailed) {
-            $0.deleteFailure = .requiresRecentLogin
-        }
-    }
-
-    func test_confirmDeleteAccount_네트워크에러() async {
-        var initial = ProfileFeature.State()
-        initial.showDeleteAlert = true
-
-        let store = TestStore(initialState: initial) {
-            ProfileFeature()
-        } withDependencies: {
-            $0.authClient.deleteAccount = { throw AuthError.network }
-            $0.authClient.currentUser = { nil }
-            $0.userClient.deleteAllData = { _ in }
-        }
-
-        await store.send(.confirmDeleteAccount) {
-            $0.showDeleteAlert = false
-        }
-        await store.receive(\.deleteAccountFailed) {
-            $0.deleteFailure = .network
-        }
-    }
-
-    func test_confirmDeleteAccount_일반에러() async {
-        struct SomeError: Error {}
-        var initial = ProfileFeature.State()
-        initial.showDeleteAlert = true
-
-        let store = TestStore(initialState: initial) {
-            ProfileFeature()
-        } withDependencies: {
-            $0.authClient.deleteAccount = { throw SomeError() }
-            $0.authClient.currentUser = { nil }
-            $0.userClient.deleteAllData = { _ in }
-        }
-
-        await store.send(.confirmDeleteAccount) {
-            $0.showDeleteAlert = false
-        }
-        await store.receive(\.deleteAccountFailed) {
-            $0.deleteFailure = .general
-        }
     }
 
     func test_dismissDeleteError_relogin필요시_signOut후_delegate() async {

--- a/Projects/Feature/Root/Sources/RootFeature.swift
+++ b/Projects/Feature/Root/Sources/RootFeature.swift
@@ -91,8 +91,12 @@ public struct RootFeature {
                     )
                 } else {
                     state.mainTab.profile.userProfile = UserProfile()
+                    state.mainTab.userId = nil
                     state.mode = .login
-                    return .cancel(id: CancelID.userObserver)
+                    return .merge(
+                        .cancel(id: CancelID.userObserver),
+                        .send(.mainTab(.sessionEnded))
+                    )
                 }
 
             case .userProfileUpdated(let profile):
@@ -112,12 +116,18 @@ public struct RootFeature {
             case .mainTab(.profile(.delegate(.didSignOut))):
                 state.mainTab = MainTabFeature.State()
                 state.mode = .login
-                return .cancel(id: CancelID.userObserver)
+                return .merge(
+                    .cancel(id: CancelID.userObserver),
+                    .send(.mainTab(.sessionEnded))
+                )
 
             case .mainTab(.profile(.delegate(.didDeleteAccount))):
                 state.mainTab = MainTabFeature.State()
                 state.mode = .login
-                return .cancel(id: CancelID.userObserver)
+                return .merge(
+                    .cancel(id: CancelID.userObserver),
+                    .send(.mainTab(.sessionEnded))
+                )
 
             case .mainTab:
                 return .none

--- a/Projects/Feature/Root/Sources/RootFeature.swift
+++ b/Projects/Feature/Root/Sources/RootFeature.swift
@@ -110,10 +110,12 @@ public struct RootFeature {
                 return .none
 
             case .mainTab(.profile(.delegate(.didSignOut))):
+                state.mainTab = MainTabFeature.State()
                 state.mode = .login
                 return .cancel(id: CancelID.userObserver)
 
             case .mainTab(.profile(.delegate(.didDeleteAccount))):
+                state.mainTab = MainTabFeature.State()
                 state.mode = .login
                 return .cancel(id: CancelID.userObserver)
 


### PR DESCRIPTION
## Summary
- 계정 삭제(탈퇴하기) 시 Firebase Auth 에러가 무시되던 문제 수정 — AuthError 분류 및 사용자 안내 메시지 추가
- 탈퇴 시 Firestore 데이터(records, goals, nicknames, user doc)가 삭제되지 않던 문제 수정
- 계정 전환(Google 탈퇴 → Apple 로그인) 시 온보딩/닉네임 입력이 스킵되던 버그 수정
  - stale Firestore observer 이벤트가 리셋된 상태를 오염시키는 것이 원인
  - `sessionEnded` 액션으로 observer 명시적 취소 + `userId` 가드 추가
- 탈퇴 확인 시 즉시 로그인 화면 전환 (백그라운드 삭제 처리)
- 튜토리얼 텍스트 수정 ("별자리우주예요")
- 버전 1.0.0 → 1.0.1

## Test plan
- [x] 계정 삭제 후 Firestore 데이터(records, goals, nicknames, user doc) 정리 확인
- [x] requiresRecentLogin 에러 시 로그아웃 후 로그인 화면 이동 확인
- [x] 탈퇴 확인 → 즉시 로그인 화면 전환 확인
- [x] Google 탈퇴 → Apple 로그인 시 온보딩/닉네임 정상 표시 확인
- [x] ProfileFeature 테스트 14개 전체 통과 (전체 38개 0 failures)
- [ ] 로그아웃 후 재로그인 시 기존 데이터 유지 확인

Closes #4